### PR TITLE
added components for the main exchange courses page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,8 +1,9 @@
 import "./App.css";
 import AuthPage from "./views/AuthPage";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
-import UserformPage from "./views/userFormPage";
 import { UserProvider } from "./contexts/UserContext";
+import UserformPage from "./views/userFormPage";
+import ExchangePage from "./views/ExchangeCoursesPage";
 import ApiProvider from "./contexts/ApiProvider";
 
 function App() {
@@ -10,9 +11,9 @@ function App() {
     <ApiProvider>
       <UserProvider>
         <BrowserRouter>
-            {/* <h1>Course Swap</h1> */}
             <Routes>
-              <Route path="/" element={<AuthPage />} />
+              <Route path="/" element={<ExchangePage />} />
+              <Route path="/auth" element={<AuthPage />} />
               <Route path="/userform" element={<UserformPage />} />
             </Routes>
         </BrowserRouter>

--- a/frontend/src/components/ExchangeCourses/MyCourses/MyCourseItem.jsx
+++ b/frontend/src/components/ExchangeCourses/MyCourses/MyCourseItem.jsx
@@ -1,0 +1,21 @@
+import React from "react";
+import Box from "@mui/material/Box";
+
+const MyCourseItem = ({ title }) => {
+  return (
+    <Box
+      sx={{
+        bgcolor: "background.paper",
+        boxShadow: 1,
+        borderRadius: 2,
+        p: 2,
+        minWidth: 275,
+        marginBottom: 2,
+      }}
+    >
+      {title}
+    </Box>
+  );
+};
+
+export default MyCourseItem;

--- a/frontend/src/components/ExchangeCourses/MyCourses/MyCoursesList.jsx
+++ b/frontend/src/components/ExchangeCourses/MyCourses/MyCoursesList.jsx
@@ -1,0 +1,37 @@
+import React from "react";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import MyCourse from "./MyCourseItem";
+
+const MyCoursesList = () => {
+  return (
+    <Box
+      sx={{
+        maxWidth: 360,
+        bgcolor: "#f0f0f0",
+        padding: 2,
+        borderRadius: 2,
+        boxShadow: 3,
+      }}
+    >
+      <Typography
+        variant="h5"
+        component="h2"
+        sx={{
+          fontWeight: "bold",
+          marginBottom: 2,
+          textAlign: "center",
+          color: "#333",
+        }}
+      >
+        My Courses
+      </Typography>
+      <MyCourse title="CS114" />
+      <MyCourse title="CS162" />
+      <MyCourse title="CS110" />
+      {/* Add more MyCourse components as needed */}
+    </Box>
+  );
+};
+
+export default MyCoursesList;

--- a/frontend/src/components/ExchangeCourses/Pickup/PickupCourseItem.jsx
+++ b/frontend/src/components/ExchangeCourses/Pickup/PickupCourseItem.jsx
@@ -1,0 +1,21 @@
+import React from "react";
+import Box from "@mui/material/Box";
+
+const PickupCourseItem = ({ title }) => {
+  return (
+    <Box
+      sx={{
+        bgcolor: "background.paper",
+        boxShadow: 1,
+        borderRadius: 2,
+        p: 2,
+        minWidth: 275,
+        marginBottom: 2,
+      }}
+    >
+      {title}
+    </Box>
+  );
+};
+
+export default PickupCourseItem;

--- a/frontend/src/components/ExchangeCourses/Pickup/PickupsList.jsx
+++ b/frontend/src/components/ExchangeCourses/Pickup/PickupsList.jsx
@@ -1,0 +1,37 @@
+import React from "react";
+import Box from "@mui/material/Box";
+import PickupCourseItem from "./PickupCourseItem";
+import Typography from "@mui/material/Typography";
+
+const PickupsList = () => {
+  return (
+    <Box
+      sx={{
+        maxWidth: 360,
+        bgcolor: "#f0f0f0",
+        padding: 2,
+        borderRadius: 2,
+        boxShadow: 3,
+      }}
+    >
+      <Typography
+        variant="h5"
+        component="h2"
+        sx={{
+          fontWeight: "bold",
+          marginBottom: 2,
+          textAlign: "center",
+          color: "#333",
+        }}
+      >
+        Pickup Courses
+      </Typography>
+      <PickupCourseItem title="Course 1A" />
+      <PickupCourseItem title="Course 1B" />
+      <PickupCourseItem title="Course 1C" />
+      {/* Add more MyCourse components as needed */}
+    </Box>
+  );
+};
+
+export default PickupsList;

--- a/frontend/src/components/ExchangeCourses/Swap/CourseToSwapItem.jsx
+++ b/frontend/src/components/ExchangeCourses/Swap/CourseToSwapItem.jsx
@@ -1,0 +1,21 @@
+import React from "react";
+import Box from "@mui/material/Box";
+
+const CourseToSwapItem = ({ title }) => {
+  return (
+    <Box
+      sx={{
+        bgcolor: "background.paper",
+        boxShadow: 1,
+        borderRadius: 2,
+        p: 2,
+        minWidth: 275,
+        marginBottom: 2,
+      }}
+    >
+      {title}
+    </Box>
+  );
+};
+
+export default CourseToSwapItem;

--- a/frontend/src/components/ExchangeCourses/Swap/SwapList.jsx
+++ b/frontend/src/components/ExchangeCourses/Swap/SwapList.jsx
@@ -1,0 +1,37 @@
+import React from "react";
+import Box from "@mui/material/Box";
+import CourseToSwapItem from "./CourseToSwapItem";
+import { Typography } from "@mui/material";
+
+const SwapList = () => {
+  return (
+    <Box
+      sx={{
+        maxWidth: 360,
+        bgcolor: "#f0f0f0",
+        padding: 2,
+        borderRadius: 2,
+        boxShadow: 3,
+      }}
+    >
+      <Typography
+        variant="h5"
+        component="h2"
+        sx={{
+          fontWeight: "bold",
+          marginBottom: 2,
+          textAlign: "center",
+          color: "#333",
+        }}
+      >
+        Swap Courses
+      </Typography>
+      <CourseToSwapItem title="Course 1A" />
+      <CourseToSwapItem title="Course 1B" />
+      <CourseToSwapItem title="Course 1C" />
+      {/* Add more MyCourse components as needed */}
+    </Box>
+  );
+};
+
+export default SwapList;

--- a/frontend/src/views/ExchangeCoursesPage.jsx
+++ b/frontend/src/views/ExchangeCoursesPage.jsx
@@ -1,0 +1,25 @@
+import React from "react";
+import Box from "@mui/material/Box";
+import MyCourseList from "../components/ExchangeCourses/MyCourses/MyCoursesList";
+import PickupsList from "../components/ExchangeCourses/Pickup/PickupsList";
+import SwapList from "../components/ExchangeCourses/Swap/SwapList";
+
+const ExchangeCoursesPage = () => {
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        justifyContent: "center", // Align items to the center
+        alignItems: "flex-start", // Align items to the start of the cross axis
+        padding: 3,
+        gap: 2, // Adjust the gap to your preference for spacing between the lists
+      }}
+    >
+      <MyCourseList />
+      <SwapList />
+      <PickupsList />
+    </Box>
+  );
+};
+
+export default ExchangeCoursesPage;


### PR DESCRIPTION

Created the components for the main exchange page. This includes 3 list components and 3 course item components. Modified routing for this to be the main page. 


![Screenshot 2023-11-03 at 22 27 55](https://github.com/minerva-university/CourseSwaps/assets/38117050/8baddf38-46fd-4466-9821-27b9774bdc4d)


How to Test:

navigate to main page /


Checklist:
- [x]  I have performed a self-review of my own code.

