### PR TITLE
Create courses_currently_offered

### DIFF
--- a/backend/API/courses_data/courses_currently_offered
+++ b/backend/API/courses_data/courses_currently_offered
@@ -1,0 +1,1232 @@
+{
+    "courses": [
+        {
+            "courseId": "NS50",
+            "courseName": "Empirical Analysis",
+            "preReqs": [
+                [
+                    "None"
+                ]
+            ],
+            "Colleges": [
+                "All"
+            ],
+            "offered_in_spring2024": false
+        },
+        {
+            "courseId": "NS51",
+            "courseName": "Empirical Analysis",
+            "preReqs": [
+                [
+                    "None"
+                ]
+            ],
+            "Colleges": [
+                "All"
+            ],
+            "offered_in_spring2024": false
+        },
+        {
+            "courseId": "NS110U",
+            "courseName": "Physics of the Universe",
+            "preReqs": [
+                [
+                    "CS51"
+                ],
+                [
+                    "CS113"
+                ],
+                [
+                    "CS111"
+                ]
+            ],
+            "Colleges": [
+                "Natural Sciences"
+            ],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Monday, Wednesday",
+                    "startTime": "19:00",
+                    "timezone": "Europe/Berlin"
+                }
+            ]
+        },
+        {
+            "courseId": "NS111",
+            "courseName": "Implications of Earth's Cycles",
+            "preReqs": [
+                [
+                    "NS51"
+                ]
+            ],
+            "Colleges": [
+                "Natural Sciences"
+            ],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Tuesday, Thursday",
+                    "startTime": "15:00",
+                    "timezone": "Europe/Berlin"
+                }
+            ]
+        },
+        {
+            "courseId": "NS112",
+            "courseName": "Evolution Across Multiple Scales",
+            "preReqs": [
+                [
+                    "NS51"
+                ]
+            ],
+            "Colleges": [
+                "Natural Sciences"
+            ],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Tuesday, Thursday",
+                    "startTime": "17:00",
+                    "timezone": "Europe/Berlin"
+                }
+            ]
+        },
+        {
+            "courseId": "NS113",
+            "courseName": "Chemical Structure and Reactivity",
+            "preReqs": [
+                [
+                    "NS51"
+                ]
+            ],
+            "Colleges": [
+                "Natural Sciences"
+            ],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Tuesday, Thursday",
+                    "startTime": "19:00",
+                    "timezone": "Europe/Berlin"
+                }
+            ]
+        },
+        {
+            "courseId": "NS125",
+            "courseName": "Research Methods",
+            "preReqs": [
+                [
+                    "NS51"
+                ]
+            ],
+            "Colleges": [
+                "Natural Sciences"
+            ],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Tuesday, Thursday",
+                    "startTime": "16:00",
+                    "timezone": "Europe/London"
+                }
+            ]
+        },
+        {
+            "courseId": "NS142",
+            "courseName": "Quantum Nature of Matter: Theory and Applications",
+            "preReqs": [
+                [
+                    "NS110U"
+                ],
+                [
+                    "CS111"
+                ],
+                [
+                    "CS113"
+                ]
+            ],
+            "Colleges": [
+                "Natural Sciences"
+            ],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Monday, Wednesday",
+                    "startTime": "20:00",
+                    "timezone": "Europe/London"
+                }
+            ]
+        },
+        {
+            "courseId": "NS144",
+            "courseName": "Genes to Organisms",
+            "preReqs": [
+                [
+                    "NS112"
+                ]
+            ],
+            "Colleges": [
+                "Natural Sciences"
+            ],
+            "offered_in_spring2024": false
+        },
+        {
+            "courseId": "NS146",
+            "courseName": "Integrating Earth's Systems",
+            "preReqs": [
+                [
+                    "NS111"
+                ]
+            ],
+            "Colleges": [
+                "Natural Sciences"
+            ],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Tuesday, Thursday",
+                    "startTime": "14:00",
+                    "timezone": "Europe/London"
+                }
+            ]
+        },
+        {
+            "courseId": "NS152",
+            "courseName": "Analyzing Matter and Molecules",
+            "preReqs": [
+                [
+                    "NS110"
+                ],
+                [
+                    "CS11"
+                ],
+                [
+                    "NS113"
+                ]
+            ],
+            "Colleges": [
+                "Natural Sciences"
+            ],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Monday, Wednesday",
+                    "startTime": "14:00",
+                    "timezone": "Europe/London"
+                }
+            ]
+        },
+        {
+            "courseId": "NS154",
+            "courseName": "Life's Chemistry",
+            "preReqs": [
+                [
+                    "NS112"
+                ],
+                [
+                    "NS113"
+                ]
+            ],
+            "Colleges": [
+                "Natural Sciences"
+            ],
+            "offered_in_spring2024": false
+        },
+        {
+            "courseId": "NS156",
+            "courseName": "Monitoring and Modeling Earth's Systems",
+            "preReqs": [
+                [
+                    "CS111"
+                ],
+                [
+                    "CS130"
+                ],
+                [
+                    "NS111"
+                ],
+                [
+                    "NS113"
+                ]
+            ],
+            "Colleges": [
+                "Natural Sciences"
+            ],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Monday, Wednesday",
+                    "startTime": "16:00",
+                    "timezone": "Europe/London"
+                }
+            ]
+        },
+        {
+            "courseId": "NS162",
+            "courseName": "Statistical Mechanics: Theory and Applications",
+            "preReqs": [
+                [
+                    "CS111"
+                ],
+                [
+                    "NS110U"
+                ],
+                [
+                    "NS110L"
+                ],
+                [
+                    "NS113"
+                ]
+            ],
+            "Colleges": [
+                "Natural Sciences"
+            ],
+            "offered_in_spring2024": false
+        },
+        {
+            "courseId": "NS164",
+            "courseName": "Solutions From and For Life",
+            "preReqs": [
+                [
+                    "NS112"
+                ]
+            ],
+            "Colleges": [
+                "Natural Sciences"
+            ],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Tuesday, Thursday",
+                    "startTime": "20:00",
+                    "timezone": "Europe/London"
+                }
+            ]
+        },
+        {
+            "courseId": "NS166",
+            "courseName": "Keeping Earth Habitable",
+            "preReqs": [
+                [
+                    "NS112"
+                ],
+                [
+                    "NS111"
+                ]
+            ],
+            "Colleges": [
+                "Natural Sciences"
+            ],
+            "offered_in_spring2024": false
+        },
+        {
+            "courseId": "SS50",
+            "courseName": "Complex Systems",
+            "preReqs": [
+                [
+                    "None"
+                ]
+            ],
+            "Colleges": [
+                "Social Sciences"
+            ],
+            "offered_in_spring2024": false
+        },
+        {
+            "courseId": "SS51",
+            "courseName": "Complex Systems",
+            "preReqs": [
+                [
+                    "SS50"
+                ]
+            ],
+            "Colleges": [
+                "Social Sciences"
+            ],
+            "offered_in_spring2024": false
+        },
+        {
+            "courseId": "SS110",
+            "courseName": "Psychology: From Neurons to Society",
+            "preReqs": [
+                [
+                    "SS51"
+                ]
+            ],
+            "Colleges": [
+                "Social Sciences"
+            ],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Tuesday, Thursday",
+                    "startTime": "17:00",
+                    "timezone": "Europe/Berlin"
+                },
+                {
+                    "days": "Monday, Wednesday",
+                    "startTime": "19:00",
+                    "timezone": "Europe/Berlin"
+                }
+            ]
+        },
+        {
+            "courseId": "SS111",
+            "courseName": "Modern Economic Thought",
+            "preReqs": [
+                [
+                    "SS51"
+                ]
+            ],
+            "Colleges": [
+                "Social Sciences"
+            ],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Tuesday, Thursday",
+                    "startTime": "17:00",
+                    "timezone": "Europe/Berlin"
+                },
+                {
+                    "days": "Tuesday, Thursday",
+                    "startTime": "19:00",
+                    "timezone": "Europe/Berlin"
+                }
+            ]
+        },
+        {
+            "courseId": "SS112",
+            "courseName": "Political Science and Social Change",
+            "preReqs": [
+                [
+                    "SS51"
+                ]
+            ],
+            "Colleges": [
+                "Social Sciences"
+            ],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Monday, Wednesday",
+                    "startTime": "17:00",
+                    "timezone": "Europe/Berlin"
+                }
+            ]
+        },
+        {
+            "courseId": "SS142",
+            "courseName": "Theories of Cognition and Emotion",
+            "preReqs": [
+                [
+                    "SS110"
+                ]
+            ],
+            "Colleges": [
+                "Social Sciences"
+            ],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Tuesday, Thursday",
+                    "startTime": "14:00",
+                    "timezone": "Europe/London"
+                },
+                {
+                    "days": "Monday, Wednesday",
+                    "startTime": "20:00",
+                    "timezone": "Europe/London"
+                }
+            ]
+        },
+        {
+            "courseId": "SS144",
+            "courseName": "Intermediate Economic Theory and Tools",
+            "preReqs": [
+                [
+                    "SS111"
+                ]
+            ],
+            "Colleges": [
+                "Social Sciences"
+            ],
+            "offered_in_spring2024": false
+        },
+        {
+            "courseId": "SS146",
+            "courseName": "Practice of Governance",
+            "preReqs": [
+                [
+                    "SS112"
+                ]
+            ],
+            "Colleges": [
+                "Social Sciences"
+            ],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Monday, Wednesday",
+                    "startTime": "14:00",
+                    "timezone": "Europe/London"
+                }
+            ]
+        },
+        {
+            "courseId": "SS152",
+            "courseName": "Cognitive Neuroscience",
+            "preReqs": [
+                [
+                    "SS110"
+                ]
+            ],
+            "Colleges": [
+                "Social Sciences"
+            ],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Tuesday, Thursday",
+                    "startTime": "18:00",
+                    "timezone": "Europe/London"
+                }
+            ]
+        },
+        {
+            "courseId": "SS154",
+            "courseName": "Econometrics and Economic Systems",
+            "preReqs": [
+                [
+                    "SS111"
+                ]
+            ],
+            "Colleges": [
+                "Social Sciences"
+            ],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Tuesday, Thursday",
+                    "startTime": "12:00",
+                    "timezone": "Europe/London"
+                },
+                {
+                    "days": "Tuesday, Thursday",
+                    "startTime": "20:00",
+                    "timezone": "Europe/London"
+                }
+            ]
+        },
+        {
+            "courseId": "SS156",
+            "courseName": "Comparative Politics in Practice",
+            "preReqs": [
+                [
+                    "SS112"
+                ]
+            ],
+            "Colleges": [
+                "Social Sciences"
+            ],
+            "offered_in_spring2024": false
+        },
+        {
+            "courseId": "SS162",
+            "courseName": "Personal and Social Motivation",
+            "preReqs": [
+                [
+                    "SS110"
+                ]
+            ],
+            "Colleges": [
+                "Social Sciences"
+            ],
+            "offered_in_spring2024": false
+        },
+        {
+            "courseId": "SS164",
+            "courseName": "Global Development and Applied Economics",
+            "preReqs": [
+                [
+                    "SS111"
+                ]
+            ],
+            "Colleges": [
+                "Social Sciences"
+            ],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Monday, Wednesday",
+                    "startTime": "12:00",
+                    "timezone": "Europe/London"
+                }
+            ]
+        },
+        {
+            "courseId": "SS166",
+            "courseName": "Comparative Constitutional Law: Designing Societies",
+            "preReqs": [
+                [
+                    "SS112"
+                ]
+            ],
+            "Colleges": [
+                "Social Sciences"
+            ],
+            "offered_in_spring2024": false
+        },
+        {
+            "courseId": "B110",
+            "courseName": "Market Dynamics and Product Analytics",
+            "preReqs": [
+                [
+                    "B111"
+                ],
+                ["AH51"],["CS51"], ["NS51"],["SS51"]
+            ],
+            "Colleges": [
+                "Business"
+            ],
+            "offered_in_spring2024": false
+        },
+        {
+            "courseId": "B111",
+            "courseName": "Financial Planning, Budgeting and Modeling",
+            "preReqs": [
+                [
+                    "B110"
+                ],
+                ["AH51"],["CS51"], ["NS51"],["SS51"]
+            ],
+            "Colleges": [
+                "Business"
+            ],
+            "offered_in_spring2024": false
+        },
+        {
+            "courseId": "B112",
+            "courseName": "Doing Business",
+            "preReqs": [
+                [
+                    "B113"
+                ],
+                ["B110"],["B111"]
+            ],
+
+            "Colleges": [
+                "Business"
+            ],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Tuesday, Thursday",
+                    "startTime": "19:00",
+                    "timezone": "Europe/Berlin"
+                },
+                {
+                    "days": "Monday, Wednesday",
+                    "startTime": "17:00",
+                    "timezone": "Europe/Berlin"
+                },
+                {
+                    "days": "Tuesday, Thursday",
+                    "startTime": "15:00",
+                    "timezone": "Europe/Berlin"
+                }
+            ]
+        },
+        {
+            "courseId": "B113",
+            "courseName": "Enterprise, Design and Optimization",
+            "preReqs": [
+                [
+                    "B112"
+                ],
+                ["B110"],["B111"]
+            ],
+
+            "Colleges": [
+                "Business"
+            ],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Monday, Wednesday",
+                    "startTime": "19:00",
+                    "timezone": "Europe/Berlin"
+                },
+                {
+                    "days": "Monday, Wednesday",
+                    "startTime": "21:00",
+                    "timezone": "Europe/Berlin"
+                },
+                {
+                    "days": "Tuesday, Thursday",
+                    "startTime": "15:00",
+                    "timezone": "Europe/Berlin"
+                }
+            ]
+        },
+        {
+            "courseId": "B144",
+            "courseName": "Needs Identification and Product Development",
+            "preReqs": [
+                [
+                    "B112"
+                ],
+                ["B113"]
+            ],
+
+            "Colleges": [
+                "Business"
+            ],
+            "offered_in_spring2024": false
+        },
+        {
+            "courseId": "B145",
+            "courseName": "Venture Initiation and Valuation",
+            "preReqs": [
+                [
+                    "B112"
+                ],
+                ["B113"]
+            ],
+
+            "Colleges": [
+                "Business"
+            ],
+            "offered_in_spring2024": false
+        },
+        {
+            "courseId": "B146",
+            "courseName": "Business Operations",
+            "preReqs": [["B112"], ["B113"]],
+            "Colleges": ["Business"],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Tuesday, Thursday",
+                    "startTime": "18:00",
+                    "timezone": "Europe/London"
+                }
+            ]
+          },
+          {
+            "courseId": "B154",
+            "courseName": "Strategic Brand Leadership",
+            "preReqs": [["B112"], ["B113"]],
+            "Colleges": ["Business"],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Monday, Wednesday",
+                    "startTime": "20:00",
+                    "timezone": "Europe/London"
+                },
+                {
+                    "days": "Tuesday, Thursday",
+                    "startTime": "16:00",
+                    "timezone": "Europe/London"
+                }
+
+            ]
+          },
+          {
+            "courseId": "B155",
+            "courseName": "Capital Allocation and Value Creating Growth",
+            "preReqs": [["B112"], ["B113"]],
+            "Colleges": ["Business"],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Tuesday, Thursday",
+                    "startTime": "20:00",
+                    "timezone": "Europe/London"
+                }
+            ]
+          },
+
+          {
+            "courseId": "B156",
+            "courseName": "Business Systems",
+            "preReqs": [["B112"], ["B113"]],
+            "Colleges": ["Business"],
+            "offered_in_spring2024": false
+          },
+          {
+            "courseId": "B164",
+            "courseName": "Product Evolution and Reinvention",
+            "preReqs": [["B112"], ["B113"]],
+            "Colleges": ["Business"],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Tuesday, Thursday",
+                    "startTime": "20:00",
+                    "timezone": "Europe/London"
+                }
+            ]
+          },
+          {
+            "courseId": "B165",
+            "courseName": "Global Enterprise Financial Strategy",
+            "preReqs": [["B112"], ["B113"]],
+            "Colleges": ["Business"],
+            "offered_in_spring2024": false
+          },
+          {
+            "courseId": "B166",
+            "courseName": "Business Optimization",
+            "preReqs": [["B112"], ["B113"]],
+            "Colleges": ["Business"],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Tuesday, Thursday",
+                    "startTime": "10:00",
+                    "timezone": "Europe/London"
+                }
+            ]
+          },
+          {
+            "courseId": "B199",
+            "courseName": "Business Practicum",
+            "preReqs": [["B112"], ["B113"]],
+            "Colleges": ["Business"],
+            "offered_in_spring2024": false
+          },
+          {
+            "courseId": "CS50",
+            "courseName": "Formal Analyses",
+            "preReqs": [["None"]],
+            "Colleges": ["Computational Sciences"],
+            "offered_in_spring2024": false
+          },
+          {
+            "courseId": "CS51",
+            "courseName": "Formal Analyses",
+            "preReqs": [["CS50"]],
+            "Colleges": ["Computational Sciences"],
+            "offered_in_spring2024": false
+          },
+          {
+            "courseId": "CS51B",
+            "courseName": "Programming",
+            "preReqs": [["CS50"]],
+            "Colleges": ["Computational Sciences"],
+            "offered_in_spring2024": false
+          },
+          {
+            "courseId": "CS110",
+            "courseName": "Problem Solving with Data Structures and Algorithms",
+            "preReqs": [["CS51"], ["CS51B"]],
+            "Colleges": ["Computational Sciences"],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Monday, Wednesday",
+                    "startTime": "13:00",
+                    "timezone": "Europe/Berlin"
+                },
+                {
+                    "days": "Monday, Wednesday",
+                    "startTime": "11:00",
+                    "timezone": "Europe/Berlin"
+                }
+            ]
+          },
+          {
+            "courseId": "CS111",
+            "courseName": "Single and Multivariable Calculus",
+            "preReqs": [["CS51"]],
+            "Colleges": ["Computational Sciences"],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Tuesday, Thursday",
+                    "startTime": "19:00",
+                    "timezone": "Europe/Berlin"
+                }
+            ]
+          },
+          {
+            "courseId": "CS113",
+            "courseName": "Theory and Applications of Linear Algebra",
+            "preReqs": [["CS51"]],
+            "Colleges": ["Computational Sciences"],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Monday, Wednesday",
+                    "startTime": "19:00",
+                    "timezone": "Europe/Berlin"
+                },
+                {
+                    "days": "Monday, Wednesday",
+                    "startTime": "21:00",
+                    "timezone": "Europe/Berlin"
+                },
+                {
+                    "days": "Tuesday, Thursday",
+                    "startTime": "19:00",
+                    "timezone": "Europe/Berlin"
+                }
+            ]
+          },
+          {
+            "courseId": "CS114",
+            "courseName": "Probability and Statistics and the Structure of Randomness",
+            "preReqs": [["CS111"]],
+            "Colleges": ["Computational Sciences"],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Monday, Wednesday",
+                    "startTime": "13:00",
+                    "timezone": "Europe/Berlin"
+                },
+                {
+                    "days": "Monday, Wednesday",
+                    "startTime": "11:00",
+                    "timezone": "Europe/Berlin"
+                },
+                {
+                    "days": "Tuesday, Thursday",
+                    "startTime": "15:00",
+                    "timezone": "Europe/Berlin"
+                },
+                {
+                    "days": "Tuesday, Thursday",
+                    "startTime": "17:00",
+                    "timezone": "Europe/Berlin"
+                }
+            ]
+          },
+          {
+            "courseId": "CS130",
+            "courseName": "Prediction and Causal Inference via Statistical Modeling",
+            "preReqs": [["CS51"]],
+            "Colleges": ["Computational Sciences"],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Tuesday, Thursday",
+                    "startTime": "18:00",
+                    "timezone": "Europe/London"
+                }
+            ]
+          },
+          {
+            "courseId": "CS142",
+            "courseName": "Theory of Computation",
+            "preReqs": [["CS110"], ["CS113"]],
+            "Colleges": ["Computational Sciences"],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Monday, Wednesday",
+                    "startTime": "15:00",
+                    "timezone": "Europe/London"
+                },
+                {
+                    "days": "Tuesday, Thursday",
+                    "startTime": "20:00",
+                    "timezone": "Europe/London"
+                }
+            ]
+          },
+          {
+            "courseId": "CS144",
+            "courseName": "Real Analysis",
+            "preReqs": [["CS111A"], ["CS111"]],
+            "Colleges": ["Computational Sciences"],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Tuesday, Thursday",
+                    "startTime": "16:00",
+                    "timezone": "Europe/London"
+                }
+            ]
+          },
+          {
+            "courseId": "CS146",
+            "courseName": "Computational Methods for Bayesian Statistics",
+            "preReqs": [["CS111A"], ["CS111"], ["CS112"], ["CS114"], ["CS130"]],
+            "Colleges": ["Computational Sciences"],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Monday, Wednesday",
+                    "startTime": "8:00",
+                    "timezone": "Europe/London"
+                },
+                {
+                    "days": "Tuesday, Thursday",
+                    "startTime": "8:00",
+                    "timezone": "Europe/London"
+                }
+            ]
+          },
+          {
+            "courseId": "CS152",
+            "courseName": "Theory and Applications of Artificial Intelligence",
+            "preReqs": [["CS110"]],
+            "Colleges": ["Computational Sciences"],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Monday, Wednesday",
+                    "startTime": "12:00",
+                    "timezone": "Europe/London"
+                },
+                {
+                    "days": "Tuesday, Thursday",
+                    "startTime": "12:00",
+                    "timezone": "Europe/London"
+                }
+            ]
+          },
+          {
+            "courseId": "CS154",
+            "courseName": "Analytical and Numerical Methods in Differential Equations",
+            "preReqs": [["CS111A"], ["CS111"], ["CS111B"], ["CS113"]],
+            "Colleges": ["Computational Sciences"],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Monday, Wednesday",
+                    "startTime": "12:00",
+                    "timezone": "Europe/London"
+                }
+            ]
+          },
+          {
+            "courseId": "CS156",
+            "courseName": "Finding Patterns in Data with Machine Learning",
+            "preReqs": [["CS110"], ["CS111A"], ["CS111"], ["CS111B"], ["CS113"]],
+            "Colleges": ["Computational Sciences"],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Tuesday, Thursday",
+                    "startTime": "14:00",
+                    "timezone": "Europe/London"
+                }
+            ]
+          },
+          {
+            "courseId": "CS162",
+            "courseName": "Software Engineering: Building Powerful Applications",
+            "preReqs": [["CS110"]],
+            "Colleges": ["Computational Sciences"],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Monday, Wednesday",
+                    "startTime": "8:00",
+                    "timezone": "Europe/London"
+                }
+            ]
+          },
+          {
+            "courseId": "CS164",
+            "courseName": "Optimization Methods",
+            "preReqs": [["CS111A"], ["CS111"], ["CS111B"], ["CS113"]],
+            "Colleges": ["Computational Sciences"],
+            "offered_in_spring2024": false
+          },
+          {
+            "courseId": "CS166",
+            "courseName": "Modeling and Analysis of Complex Systems",
+            "preReqs": [["CS113"], ["CS114"], ["CS112"], ["CS130"]],
+            "Colleges": ["Computational Sciences"],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Monday, Wednesday",
+                    "startTime": "14:00",
+                    "timezone": "Europe/London"
+                },
+                {
+                    "days": "Monday, Wednesday",
+                    "startTime": "16:00",
+                    "timezone": "Europe/London"
+                }
+            ]
+          }, {
+            "courseId": "AH50",
+            "courseName": "Multimodal Communications",
+            "preReqs": ["None"],
+            "Colleges": ["Arts and Humanities"],
+            "offered_in_spring2024": false
+          },
+          {
+            "courseId": "AH51",
+            "courseName": "Multimodal Communications",
+            "preReqs": ["AH50"],
+            "Colleges": ["Arts and Humanities"],
+            "offered_in_spring2024": false
+          },
+          {
+            "courseId": "AH110",
+            "courseName": "Global History",
+            "preReqs": ["AH51"],
+            "Colleges": ["Arts and Humanities"],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Monday, Wednesday",
+                    "startTime": "17:00",
+                    "timezone": "Europe/Berlin"
+                }
+            ]
+          },
+          {
+            "courseId": "AH111",
+            "courseName": "Morality, Justice, and the Good Life",
+            "preReqs": ["AH51"],
+            "Colleges": ["Arts and Humanities"],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Monday, Wednesday",
+                    "startTime": "15:00",
+                    "timezone": "Europe/Berlin"
+                }
+            ]
+          },
+          {
+            "courseId": "AH112",
+            "courseName": "The Arts and Social Change",
+            "preReqs": ["AH51"],
+            "Colleges": ["Arts and Humanities"],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Tuesday, Thursday",
+                    "startTime": "13:00",
+                    "timezone": "Europe/Berlin"
+                }
+            ]
+          },
+          {
+            "courseId": "AH113",
+            "courseName": "Dynamics of Design",
+            "preReqs": ["AH51"],
+            "Colleges": ["Arts and Humanities"],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Monday, Wednesday",
+                    "startTime": "21:00",
+                    "timezone": "Europe/Berlin"
+                }
+            ]
+          },
+          {
+            "courseId": "AH142",
+            "courseName": "The Craft of Historical Analysis",
+            "preReqs": ["AH110"],
+            "Colleges": ["Arts and Humanities"],
+            "offered_in_spring2024": false
+          },
+          {
+            "courseId": "AH144",
+            "courseName": "Ethical Systems, Moral Dilemmas",
+            "preReqs": ["AH111"],
+            "Colleges": ["Arts and Humanities"],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Tuesday, Thursday",
+                    "startTime": "20:00",
+                    "timezone": "Europe/London"
+                }
+            ]
+          },
+          {
+            "courseId": "AH146",
+            "courseName": "Decoding Art and Literature",
+            "preReqs": ["AH112"],
+            "Colleges": ["Arts and Humanities"],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Tuesday, Thursday",
+                    "startTime": "14:00",
+                    "timezone": "Europe/London"
+                }
+            ]
+          },
+          {
+            "courseId": "AH152",
+            "courseName": "Comparing Societies and Histories: The Impact of Time and Place",
+            "preReqs": ["AH110"],
+            "Colleges": ["Arts and Humanities"],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Tuesday, Thursday",
+                    "startTime": "18:00",
+                    "timezone": "Europe/London"
+                }
+            ]
+          },
+          {
+            "courseId": "AH154",
+            "courseName": "Ethics and the Law",
+            "preReqs": ["AH111"],
+            "Colleges": ["Arts and Humanities"],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Monday, Wednesday",
+                    "startTime": "16:00",
+                    "timezone": "Europe/London"
+                }
+            ]
+          },
+          {
+            "courseId": "AH156",
+            "courseName": "Socioeconomic Influences on Art and Literature",
+            "preReqs": ["AH112"],
+            "Colleges": ["Arts and Humanities"], 
+            "offered_in_spring2024": false
+          },
+          {
+            "courseId": "AH162",
+            "courseName": "Public and Applied History",
+            "preReqs": ["AH110"],
+            "Colleges": ["Arts and Humanities"],
+            "offered_in_spring2024": false
+          },
+          {
+            "courseId": "AH164",
+            "courseName": "Social and Political Philosophy",
+            "preReqs": ["AH111"],
+            "Colleges": ["Arts and Humanities"],
+            "offered_in_spring2024": false
+          },
+          {
+            "courseId": "AH166",
+            "courseName": "Artistic Communication from Page to Practice",
+            "preReqs": ["AH112"],
+            "Colleges": ["Arts and Humanities"],
+            "offered_in_spring2024": true,
+            "scheduleOptions": [
+                {
+                    "days": "Tuesday, Thursday",
+                    "startTime": "16:00",
+                    "timezone": "Europe/London"
+                }
+            ]
+          }
+
+        
+    ]
+    
+}


### PR DESCRIPTION
## Description:
The JSON file previously had only an information of all the courses. I added a new section for each course that marks whether it is offered in spring 2024, and the different time offerings of the course. 

## Issue Addressed: 
marked whether the class is offered in spring 2024 and what time. 

## Changes Made:
Manually added information about the offering of each course (Days and Time) for each course:
For example:
"offered_in_spring2024": true
"scheduleOptions": [
                {
                    "days": "Monday, Wednesday",
                    "startTime": "19:00",
                    "timezone": "Europe/Berlin"
                }