### PR TITLE
fixed update swaps table when user drops course

### DIFF
--- a/backend/API/blueprints/availableforpickup.py
+++ b/backend/API/blueprints/availableforpickup.py
@@ -197,7 +197,7 @@ def drop_course():
         # Additionally, remove any swap requests for the dropped course
         swap_requests = (
             db.session.query(CoursesAvailableToSwap)
-            .filter_by(course_id=course_id)
+            .filter_by(giving_course_id=course_id)
             .all()
         )
         for swap_request in swap_requests:


### PR DESCRIPTION
Description:
Modified the drop course endpoint so that the swaps table is updated accordingly when a user drops a course. This addresses the swap requests involving a dropped course that remained active.

Issue Addressed: #108 - Update Swaps Table When User Drops Course

Changes Made:
Change 1: Modification in drop course endpoint 

Testing: 
Step 1: Run Backend Tests

Checklist:
I have performed a self-review of my own code.
I have commented on my code where necessary to clarify changes and logic.
The code has passed all tests, confirming that the changes maintain functionality and resolve the issue as intended.
