### PR TITLE
fixed drop and swap buttons orientation

### DIFF
--- a/frontend/src/components/ExchangeCourses/MyCourses/MyCoursesList.jsx
+++ b/frontend/src/components/ExchangeCourses/MyCourses/MyCoursesList.jsx
@@ -138,10 +138,9 @@ const MyCoursesList = () => {
           }}
         >
           <Typography variant="body1" sx={{ marginRight: 1 }}>
-            {" "}
             {course.code}: {course.name}
           </Typography>
-          <Box sx={{ display: "flex", gap: 1 }}>
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}> {/* Updated this line */}
             <Button
               variant="contained"
               onClick={() => handleSwapButtonClick(course)}
@@ -162,6 +161,7 @@ const MyCoursesList = () => {
           </Box>
         </Box>
       ))}
+
       <SwapForm
         open={open}
         onClose={handleCloseSwapForm}


### PR DESCRIPTION
## Description

made swap button on the top of drop button for better view when timing gets added 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
Checked how it looks on the interface

## How to Run Tests

Run the app and check the buttons orientation

## Checklist:
  - [x] My code follows the project's style guidelines
  - [x] I have performed a self-review of my own code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable):
<img width="341" alt="Screenshot 2023-12-15 at 17 50 57" src="https://github.com/minerva-university/CourseSwaps/assets/131557935/6144ae0f-23e8-4657-b720-5fe58d1e8934">




